### PR TITLE
Refactor game state into structured substates

### DIFF
--- a/src/core/game_state.py
+++ b/src/core/game_state.py
@@ -1,10 +1,24 @@
-from enum import Enum, auto
+"""Game state management with structured substates.
+
+This module defines the top-level :class:`GameState` along with more focused
+dataclasses for battle logic, UI/dialog handling and cursor/camera tracking.
+Splitting the state into these components makes intent clearer and keeps
+related behaviour together while still exposing a unified interface through
+``GameState`` for backwards compatibility.
+"""
+
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Optional, Any
+from enum import Enum, auto
+from typing import Any, Optional
+
 from .data_structures import Vector2, VectorArray
 
 
 class GamePhase(Enum):
+    """High level game phases."""
+
     MAIN_MENU = auto()
     BATTLE = auto()
     CUTSCENE = auto()
@@ -13,65 +27,183 @@ class GamePhase(Enum):
 
 
 class BattlePhase(Enum):
+    """Phases within a battle."""
+
     PLAYER_TURN_START = auto()
     UNIT_SELECTION = auto()
     UNIT_MOVING = auto()
     ACTION_MENU = auto()
-    TARGETING = auto()  # New phase for target selection with battle forecast
+    TARGETING = auto()  # Target selection with battle forecast
     UNIT_ACTING = auto()
     ENEMY_TURN = auto()
     TURN_END = auto()
 
 
 @dataclass
-class GameState:
-    phase: GamePhase = GamePhase.BATTLE
-    battle_phase: BattlePhase = BattlePhase.UNIT_SELECTION
-    
-    current_turn: int = 1
-    current_team: int = 0
-    
-    selected_unit_id: Optional[str] = None
-    selected_tile_position: Optional[Vector2] = None
-    
-    # Original position tracking for cancellation
-    original_unit_position: Optional[Vector2] = None
-    
-    cursor_position: Vector2 = field(default_factory=lambda: Vector2(0, 0))
-    
+class CursorState:
+    """Tracks cursor position and camera viewport."""
+
+    position: Vector2 = field(default_factory=lambda: Vector2(0, 0))
     camera_position: Vector2 = field(default_factory=lambda: Vector2(0, 0))
-    
+
+    def set_position(self, position: Vector2) -> None:
+        self.position = position
+
+    def move(self, dx: int, dy: int, max_x: int, max_y: int) -> None:
+        """Move cursor within the bounds of the map."""
+
+        new_x = max(0, min(max_x - 1, self.position.x + dx))
+        new_y = max(0, min(max_y - 1, self.position.y + dy))
+        self.position = Vector2(new_y, new_x)
+
+    def update_camera(self, viewport_width: int, viewport_height: int) -> None:
+        """Keep the camera near the cursor with a margin."""
+
+        margin = 3
+
+        if self.position.x < self.camera_position.x + margin:
+            self.camera_position = Vector2(
+                self.camera_position.y, max(0, self.position.x - margin)
+            )
+        elif self.position.x >= self.camera_position.x + viewport_width - margin:
+            self.camera_position = Vector2(
+                self.camera_position.y,
+                self.position.x - viewport_width + margin + 1,
+            )
+
+        if self.position.y < self.camera_position.y + margin:
+            self.camera_position = Vector2(
+                max(0, self.position.y - margin), self.camera_position.x
+            )
+        elif self.position.y >= self.camera_position.y + viewport_height - margin:
+            self.camera_position = Vector2(
+                self.position.y - viewport_height + margin + 1,
+                self.camera_position.x,
+            )
+
+
+@dataclass
+class UIState:
+    """Holds menu, dialog and overlay UI state."""
+
     active_menu: Optional[str] = None
     menu_selection: int = 0
-    
-    # Action menu state
+
     active_action_menu: bool = False
     action_menu_items: list[str] = field(default_factory=list)
     action_menu_selection: int = 0
-    
-    # Strategic TUI overlay states
+
     active_overlay: Optional[str] = None  # "objectives", "help", "minimap"
-    active_dialog: Optional[str] = None   # "confirm_end_turn", etc.
-    dialog_selection: int = 0             # For dialog option selection
-    active_forecast: bool = False         # Battle forecast during targeting
-    
+    active_dialog: Optional[str] = None  # "confirm_end_turn", etc.
+    dialog_selection: int = 0  # For dialog option selection
+    active_forecast: bool = False  # Battle forecast during targeting
+
+    def open_menu(self, menu_name: str) -> None:
+        self.active_menu = menu_name
+        self.menu_selection = 0
+
+    def close_menu(self) -> None:
+        self.active_menu = None
+        self.menu_selection = 0
+
+    def is_menu_open(self) -> bool:
+        return self.active_menu is not None
+
+    def open_action_menu(self, items: list[str]) -> None:
+        self.active_action_menu = True
+        self.action_menu_items = items.copy()
+        self.action_menu_selection = 0
+
+    def close_action_menu(self) -> None:
+        self.active_action_menu = False
+        self.action_menu_items.clear()
+        self.action_menu_selection = 0
+
+    def is_action_menu_open(self) -> bool:
+        return self.active_action_menu
+
+    def get_selected_action(self) -> Optional[str]:
+        if self.active_action_menu and 0 <= self.action_menu_selection < len(
+            self.action_menu_items
+        ):
+            return self.action_menu_items[self.action_menu_selection]
+        return None
+
+    def move_action_menu_selection(self, direction: int) -> None:
+        if self.active_action_menu and self.action_menu_items:
+            self.action_menu_selection = (
+                self.action_menu_selection + direction
+            ) % len(self.action_menu_items)
+
+    # Strategic TUI overlay methods
+    def open_overlay(self, overlay_type: str) -> None:
+        self.active_overlay = overlay_type
+
+    def close_overlay(self) -> None:
+        self.active_overlay = None
+
+    def is_overlay_open(self) -> bool:
+        return self.active_overlay is not None
+
+    def open_dialog(self, dialog_type: str) -> None:
+        self.active_dialog = dialog_type
+        self.dialog_selection = 0
+
+    def close_dialog(self) -> None:
+        self.active_dialog = None
+        self.dialog_selection = 0
+
+    def is_dialog_open(self) -> bool:
+        return self.active_dialog is not None
+
+    def move_dialog_selection(self, direction: int) -> None:
+        self.dialog_selection = (self.dialog_selection + direction) % 2
+
+    def get_dialog_selection(self) -> int:
+        return self.dialog_selection
+
+    def start_forecast(self) -> None:
+        self.active_forecast = True
+
+    def stop_forecast(self) -> None:
+        self.active_forecast = False
+
+    def is_forecast_active(self) -> bool:
+        return self.active_forecast
+
+    def is_any_modal_open(self) -> bool:
+        return (
+            self.is_overlay_open()
+            or self.is_dialog_open()
+            or self.is_forecast_active()
+        )
+
+
+@dataclass
+class BattleState:
+    """Encapsulates battle-specific state and behaviour."""
+
+    phase: BattlePhase = BattlePhase.UNIT_SELECTION
+
+    current_turn: int = 1
+    current_team: int = 0
+
+    selected_unit_id: Optional[str] = None
+    selected_tile_position: Optional[Vector2] = None
+    original_unit_position: Optional[Vector2] = None
+
     movement_range: VectorArray = field(default_factory=VectorArray)
     attack_range: VectorArray = field(default_factory=VectorArray)
-    
-    # Attack targeting state
+
     selected_target: Optional[Vector2] = None
     aoe_tiles: VectorArray = field(default_factory=VectorArray)
-    
-    # Unit cycling state
+
     selectable_units: list[str] = field(default_factory=list)
     current_unit_index: int = 0
-    
-    # Target cycling state  
+
     targetable_enemies: list[str] = field(default_factory=list)
     current_target_index: int = 0
-    
-    state_data: dict[str, Any] = field(default_factory=dict)
-    
+
     def reset_selection(self) -> None:
         self.selected_unit_id = None
         self.selected_tile_position = None
@@ -84,174 +216,122 @@ class GameState:
         self.current_unit_index = 0
         self.targetable_enemies.clear()
         self.current_target_index = 0
-        self.close_action_menu()
-        self.close_overlay()
-        self.close_dialog()
-        self.stop_forecast()
-    
-    def set_cursor_position(self, position: Vector2) -> None:
-        self.cursor_position = position
-    
-    def move_cursor(self, dx: int, dy: int, max_x: int, max_y: int) -> None:
-        new_x = max(0, min(max_x - 1, self.cursor_position.x + dx))
-        new_y = max(0, min(max_y - 1, self.cursor_position.y + dy))
-        self.cursor_position = Vector2(new_y, new_x)
-        # move_cursor already handles both x and y above
-    
-    
+
     def set_movement_range(self, tiles: VectorArray) -> None:
         self.movement_range = tiles
-    
+
     def set_attack_range(self, tiles: VectorArray) -> None:
         self.attack_range = tiles
-    
+
     def is_in_movement_range(self, position: Vector2) -> bool:
         return self.movement_range.contains(position)
-    
+
     def is_in_attack_range(self, position: Vector2) -> bool:
         return self.attack_range.contains(position)
-    
+
     def start_player_turn(self) -> None:
-        self.battle_phase = BattlePhase.PLAYER_TURN_START
+        self.phase = BattlePhase.PLAYER_TURN_START
         self.current_turn += 1
         self.reset_selection()
-    
+
     def start_enemy_turn(self) -> None:
-        self.battle_phase = BattlePhase.ENEMY_TURN
+        self.phase = BattlePhase.ENEMY_TURN
         self.reset_selection()
-    
-    def open_menu(self, menu_name: str) -> None:
-        self.active_menu = menu_name
-        self.menu_selection = 0
-    
-    def close_menu(self) -> None:
-        self.active_menu = None
-        self.menu_selection = 0
-    
-    def is_menu_open(self) -> bool:
-        return self.active_menu is not None
-    
-    # Action menu methods
-    def open_action_menu(self, items: list[str]) -> None:
-        self.active_action_menu = True
-        self.action_menu_items = items.copy()
-        self.action_menu_selection = 0
-    
-    def close_action_menu(self) -> None:
-        self.active_action_menu = False
-        self.action_menu_items.clear()
-        self.action_menu_selection = 0
-    
-    def is_action_menu_open(self) -> bool:
-        return self.active_action_menu
-    
-    def get_selected_action(self) -> Optional[str]:
-        if self.active_action_menu and 0 <= self.action_menu_selection < len(self.action_menu_items):
-            return self.action_menu_items[self.action_menu_selection]
-        return None
-    
-    def move_action_menu_selection(self, direction: int) -> None:
-        if self.active_action_menu and self.action_menu_items:
-            self.action_menu_selection = (self.action_menu_selection + direction) % len(self.action_menu_items)
-    
-    # Strategic TUI overlay methods
-    def open_overlay(self, overlay_type: str) -> None:
-        """Open a full-screen overlay (objectives, help, minimap)."""
-        self.active_overlay = overlay_type
-    
-    def close_overlay(self) -> None:
-        """Close the active overlay."""
-        self.active_overlay = None
-    
-    def is_overlay_open(self) -> bool:
-        """Check if any overlay is open."""
-        return self.active_overlay is not None
-    
-    def open_dialog(self, dialog_type: str) -> None:
-        """Open a confirmation dialog."""
-        self.active_dialog = dialog_type
-        self.dialog_selection = 0
-    
-    def close_dialog(self) -> None:
-        """Close the active dialog."""
-        self.active_dialog = None
-        self.dialog_selection = 0
-    
-    def is_dialog_open(self) -> bool:
-        """Check if any dialog is open."""
-        return self.active_dialog is not None
-    
-    def move_dialog_selection(self, direction: int) -> None:
-        """Move dialog selection (0=Yes, 1=No typically)."""
-        self.dialog_selection = (self.dialog_selection + direction) % 2
-    
-    def get_dialog_selection(self) -> int:
-        """Get current dialog selection."""
-        return self.dialog_selection
-    
-    def start_forecast(self) -> None:
-        """Start battle forecast display."""
-        self.active_forecast = True
-    
-    def stop_forecast(self) -> None:
-        """Stop battle forecast display."""
-        self.active_forecast = False
-    
-    def is_forecast_active(self) -> bool:
-        """Check if battle forecast is active."""
-        return self.active_forecast
-    
-    def is_any_modal_open(self) -> bool:
-        """Check if any modal UI is open (overlay, dialog, forecast)."""
-        return self.is_overlay_open() or self.is_dialog_open() or self.is_forecast_active()
-    
-    def update_camera_to_cursor(self, viewport_width: int, viewport_height: int) -> None:
-        margin = 3
-        
-        if self.cursor_position.x < self.camera_position.x + margin:
-            self.camera_position = Vector2(self.camera_position.y, max(0, self.cursor_position.x - margin))
-        elif self.cursor_position.x >= self.camera_position.x + viewport_width - margin:
-            self.camera_position = Vector2(self.camera_position.y, self.cursor_position.x - viewport_width + margin + 1)
-        
-        if self.cursor_position.y < self.camera_position.y + margin:
-            self.camera_position = Vector2(max(0, self.cursor_position.y - margin), self.camera_position.x)
-        elif self.cursor_position.y >= self.camera_position.y + viewport_height - margin:
-            self.camera_position = Vector2(self.cursor_position.y - viewport_height + margin + 1, self.camera_position.x)
-    
+
     def set_selectable_units(self, unit_ids: list[str]) -> None:
-        """Set the list of units that can be selected and reset index."""
         self.selectable_units = unit_ids.copy()
         self.current_unit_index = 0
-    
+
     def cycle_selectable_units(self) -> Optional[str]:
-        """Cycle to the next selectable unit and return its ID."""
         if not self.selectable_units:
             return None
-        
-        self.current_unit_index = (self.current_unit_index + 1) % len(self.selectable_units)
+        self.current_unit_index = (self.current_unit_index + 1) % len(
+            self.selectable_units
+        )
         return self.selectable_units[self.current_unit_index]
-    
+
     def get_current_selectable_unit(self) -> Optional[str]:
-        """Get the currently selected unit ID."""
-        if not self.selectable_units or self.current_unit_index >= len(self.selectable_units):
+        if not self.selectable_units or self.current_unit_index >= len(
+            self.selectable_units
+        ):
             return None
         return self.selectable_units[self.current_unit_index]
-    
+
     def set_targetable_enemies(self, unit_ids: list[str]) -> None:
-        """Set the list of enemies that can be targeted and reset index."""
         self.targetable_enemies = unit_ids.copy()
         self.current_target_index = 0
-    
+
     def cycle_targetable_enemies(self) -> Optional[str]:
-        """Cycle to the next targetable enemy and return its ID."""
         if not self.targetable_enemies:
             return None
-        
-        self.current_target_index = (self.current_target_index + 1) % len(self.targetable_enemies)
+        self.current_target_index = (self.current_target_index + 1) % len(
+            self.targetable_enemies
+        )
         return self.targetable_enemies[self.current_target_index]
-    
+
     def get_current_targetable_enemy(self) -> Optional[str]:
-        """Get the currently targeted enemy ID."""
-        if not self.targetable_enemies or self.current_target_index >= len(self.targetable_enemies):
+        if not self.targetable_enemies or self.current_target_index >= len(
+            self.targetable_enemies
+        ):
             return None
         return self.targetable_enemies[self.current_target_index]
+
+
+@dataclass
+class GameState:
+    """Top-level game state composed of focused substates."""
+
+    phase: GamePhase = GamePhase.BATTLE
+    battle: BattleState = field(default_factory=BattleState)
+    ui: UIState = field(default_factory=UIState)
+    cursor: CursorState = field(default_factory=CursorState)
+
+    state_data: dict[str, Any] = field(default_factory=dict)
+
+    # ------------------------------------------------------------------
+    # Compatibility helpers
+    # ------------------------------------------------------------------
+    def __getattr__(self, name: str) -> Any:  # pragma: no cover - simple delegation
+        for sub in (self.battle, self.ui, self.cursor):
+            if hasattr(sub, name):
+                return getattr(sub, name)
+        raise AttributeError(name)
+
+    def __setattr__(self, name: str, value: Any) -> None:  # pragma: no cover
+        if name in {"phase", "battle", "ui", "cursor", "state_data"}:
+            super().__setattr__(name, value)
+            return
+        for sub_name in ("battle", "ui", "cursor"):
+            sub = self.__dict__.get(sub_name)
+            if sub is not None and hasattr(sub, name):
+                setattr(sub, name, value)
+                return
+        super().__setattr__(name, value)
+
+    # ------------------------------------------------------------------
+    # Convenience methods operating across substates
+    # ------------------------------------------------------------------
+    def reset_selection(self) -> None:
+        """Reset selection state and close any active UI elements."""
+
+        self.battle.reset_selection()
+        self.ui.close_action_menu()
+        self.ui.close_overlay()
+        self.ui.close_dialog()
+        self.ui.stop_forecast()
+
+    def start_player_turn(self) -> None:
+        self.battle.start_player_turn()
+
+    def start_enemy_turn(self) -> None:
+        self.battle.start_enemy_turn()
+
+    def move_cursor(self, dx: int, dy: int, max_x: int, max_y: int) -> None:
+        self.cursor.move(dx, dy, max_x, max_y)
+
+    def set_cursor_position(self, position: Vector2) -> None:
+        self.cursor.set_position(position)
+
+    def update_camera_to_cursor(self, viewport_width: int, viewport_height: int) -> None:
+        self.cursor.update_camera(viewport_width, viewport_height)
+

--- a/src/game/combat_manager.py
+++ b/src/game/combat_manager.py
@@ -35,9 +35,9 @@ class CombatManager:
     def setup_attack_targeting(self, unit: "Unit") -> None:
         """Set up attack targeting for a unit."""
         # Clear movement range and set attack range
-        self.state.movement_range = VectorArray()
+        self.state.battle.movement_range = VectorArray()
         attack_range = self.game_map.calculate_attack_range(unit)
-        self.state.set_attack_range(attack_range)
+        self.state.battle.set_attack_range(attack_range)
         
         # Set up targetable enemies for cycling
         self.refresh_targetable_enemies(unit)
@@ -50,28 +50,28 @@ class CombatManager:
     
     def update_attack_targeting(self) -> None:
         """Update attack targeting based on cursor position."""
-        if not self.state.attack_range:
+        if not self.state.battle.attack_range:
             return
-            
-        cursor_pos = self.state.cursor_position
-        
+
+        cursor_pos = self.state.cursor.position
+
         # Check if cursor is over a valid attack target
-        if cursor_pos in self.state.attack_range:
-            self.state.selected_target = cursor_pos
-            
+        if cursor_pos in self.state.battle.attack_range:
+            self.state.battle.selected_target = cursor_pos
+
             # Calculate AOE tiles if we have a selected unit
-            if self.state.selected_unit_id:
-                unit = self.game_map.get_unit(self.state.selected_unit_id)
+            if self.state.battle.selected_unit_id:
+                unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
                 if unit and hasattr(unit.combat, "aoe_pattern"):
                     aoe_pattern = unit.combat.aoe_pattern
-                    self.state.aoe_tiles = self.game_map.calculate_aoe_tiles(
+                    self.state.battle.aoe_tiles = self.game_map.calculate_aoe_tiles(
                         cursor_pos, aoe_pattern
                     )
                 else:
-                    self.state.aoe_tiles = VectorArray([cursor_pos])
+                    self.state.battle.aoe_tiles = VectorArray([cursor_pos])
         else:
-            self.state.selected_target = None
-            self.state.aoe_tiles = VectorArray()
+            self.state.battle.selected_target = None
+            self.state.battle.aoe_tiles = VectorArray()
     
     def execute_attack_at_cursor(self) -> bool:
         """
@@ -80,15 +80,15 @@ class CombatManager:
         Returns:
             True if attack was executed, False if invalid or cancelled
         """
-        cursor_position = self.state.cursor_position
-        
-        if not self.state.is_in_attack_range(cursor_position):
+        cursor_position = self.state.cursor.position
+
+        if not self.state.battle.is_in_attack_range(cursor_position):
             return False
-            
-        if not self.state.selected_unit_id:
+
+        if not self.state.battle.selected_unit_id:
             return False
-            
-        attacker = self.game_map.get_unit(self.state.selected_unit_id)
+
+        attacker = self.game_map.get_unit(self.state.battle.selected_unit_id)
         if not attacker:
             return False
         
@@ -115,10 +115,10 @@ class CombatManager:
     
     def execute_confirmed_attack(self) -> bool:
         """Execute an attack that was confirmed by the player after friendly fire warning."""
-        if not self.state.selected_unit_id:
+        if not self.state.battle.selected_unit_id:
             return False
-            
-        attacker = self.game_map.get_unit(self.state.selected_unit_id)
+
+        attacker = self.game_map.get_unit(self.state.battle.selected_unit_id)
         if not attacker:
             return False
         
@@ -156,18 +156,18 @@ class CombatManager:
             ):
                 targetable_ids.append(target_unit.unit_id)
         
-        self.state.set_targetable_enemies(targetable_ids)
+        self.state.battle.set_targetable_enemies(targetable_ids)
     
     def position_cursor_on_closest_target(self, attacking_unit: "Unit") -> None:
         """Position cursor on the closest targetable enemy unit."""
-        if not self.state.targetable_enemies:
+        if not self.state.battle.targetable_enemies:
             return
         
         closest_target = None
         closest_distance = float("inf")
         
         # Find the closest targetable enemy unit
-        for target_id in self.state.targetable_enemies:
+        for target_id in self.state.battle.targetable_enemies:
             target_unit = self.game_map.get_unit(target_id)
             if target_unit:
                 # Calculate Manhattan distance
@@ -178,14 +178,14 @@ class CombatManager:
         
         # Position cursor on closest target
         if closest_target:
-            self.state.cursor_position = closest_target.position
-            
+            self.state.cursor.set_position(closest_target.position)
+
             # Update the target index to match the cursor position
             try:
-                target_index = self.state.targetable_enemies.index(
+                target_index = self.state.battle.targetable_enemies.index(
                     closest_target.unit_id
                 )
-                self.state.current_target_index = target_index
+                self.state.battle.current_target_index = target_index
             except ValueError:
                 pass  # Target not in list, keep current index
     
@@ -196,23 +196,23 @@ class CombatManager:
         Returns:
             True if cursor was moved to a new target
         """
-        if not self.state.selected_unit_id:
+        if not self.state.battle.selected_unit_id:
             return False
             
-        unit = self.game_map.get_unit(self.state.selected_unit_id)
+        unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
         if not unit:
             return False
         
         # Get all targetable enemy units if not already set
-        if not self.state.targetable_enemies:
+        if not self.state.battle.targetable_enemies:
             self.refresh_targetable_enemies(unit)
         
         # Cycle to next target
-        next_target_id = self.state.cycle_targetable_enemies()
+        next_target_id = self.state.battle.cycle_targetable_enemies()
         if next_target_id:
             target_unit = self.game_map.get_unit(next_target_id)
             if target_unit:
-                self.state.cursor_position = target_unit.position
+                self.state.cursor.set_position(target_unit.position)
                 return True
         
         return False
@@ -245,7 +245,7 @@ class CombatManager:
             "targets_hit": result.targets_hit,
         }
         
-        self.state.open_dialog("confirm_friendly_fire")
+        self.state.ui.open_dialog("confirm_friendly_fire")
     
     def _clear_friendly_fire_data(self) -> None:
         """Clear stored friendly fire confirmation data."""
@@ -262,7 +262,7 @@ class CombatManager:
             position = result.defeated_positions.get(target_name, (0, 0))
             if target:
                 defeat_event = self.resolver.create_defeat_event(
-                    target.name, target.team, position, self.state.current_turn
+                    target.name, target.team, position, self.state.battle.current_turn
                 )
                 self.emit_event(defeat_event)
         
@@ -272,8 +272,8 @@ class CombatManager:
         
     def clear_attack_state(self) -> None:
         """Clear all attack-related state data."""
-        self.state.attack_range = VectorArray()
-        self.state.aoe_tiles = VectorArray()
-        self.state.targetable_enemies.clear()
-        self.state.current_target_index = 0
-        self.state.selected_target = None
+        self.state.battle.attack_range = VectorArray()
+        self.state.battle.aoe_tiles = VectorArray()
+        self.state.battle.targetable_enemies.clear()
+        self.state.battle.current_target_index = 0
+        self.state.battle.selected_target = None

--- a/src/game/input_handler.py
+++ b/src/game/input_handler.py
@@ -55,18 +55,18 @@ class InputHandler:
     def handle_key_press(self, event: InputEvent) -> None:
         """Route key press events to appropriate handlers based on current state."""
         # Handle modal overlays (objectives, help, minimap)
-        if self.state.is_overlay_open():
+        if self.state.ui.is_overlay_open():
             self.handle_overlay_input(event)
         # Handle confirmation dialogs
-        elif self.state.is_dialog_open():
+        elif self.state.ui.is_dialog_open():
             self.handle_dialog_input(event)
         # Handle battle forecast during targeting
-        elif self.state.is_forecast_active():
+        elif self.state.ui.is_forecast_active():
             self.handle_forecast_input(event)
         # Handle existing modals
-        elif self.state.is_action_menu_open():
+        elif self.state.ui.is_action_menu_open():
             self.handle_action_menu_input(event)
-        elif self.state.is_menu_open():
+        elif self.state.ui.is_menu_open():
             self.handle_menu_input(event)
         else:
             self.handle_map_input(event)
@@ -79,7 +79,7 @@ class InputHandler:
             return
         
         # During non-player turns, only allow limited actions
-        if self.state.current_team != 0:  # 0 = Player team
+        if self.state.battle.current_team != 0:  # 0 = Player team
             # Only allow overlay keys during enemy/AI turns
             if event.key == Key.O:
                 self.handle_objectives_key()
@@ -127,47 +127,47 @@ class InputHandler:
         elif event.key in {Key.RIGHT, Key.D}:
             dx = 1
         
-        self.state.move_cursor(dx, dy, self.game_map.width, self.game_map.height)
+        self.state.cursor.move(dx, dy, self.game_map.width, self.game_map.height)
         
         # Update selected target and AOE tiles if in attack targeting mode
         if (
-            self.state.battle_phase == BattlePhase.UNIT_ACTING
-            and self.state.attack_range
+            self.state.battle.phase == BattlePhase.UNIT_ACTING
+            and self.state.battle.attack_range
             and self.combat_manager
         ):
             self.combat_manager.update_attack_targeting()
-        elif self.state.selected_unit_id and self.on_movement_preview_update:
+        elif self.state.battle.selected_unit_id and self.on_movement_preview_update:
             self.on_movement_preview_update()
     
     def handle_confirm(self) -> None:
         """Handle confirmation input based on current battle phase."""
-        cursor_position = self.state.cursor_position
-        
-        if self.state.battle_phase == BattlePhase.UNIT_SELECTION:
+        cursor_position = self.state.cursor.position
+
+        if self.state.battle.phase == BattlePhase.UNIT_SELECTION:
             self._handle_unit_selection_confirm(cursor_position)
-        elif self.state.battle_phase == BattlePhase.UNIT_MOVING:
+        elif self.state.battle.phase == BattlePhase.UNIT_MOVING:
             self._handle_unit_movement_confirm(cursor_position)
-        elif self.state.battle_phase == BattlePhase.ACTION_MENU:
+        elif self.state.battle.phase == BattlePhase.ACTION_MENU:
             self._handle_action_menu_confirm()
-        elif self.state.battle_phase == BattlePhase.UNIT_ACTING:
+        elif self.state.battle.phase == BattlePhase.UNIT_ACTING:
             self._handle_unit_acting_confirm()
     
     def _handle_unit_selection_confirm(self, cursor_position: Vector2) -> None:
         """Handle confirmation during unit selection phase."""
         unit = self.game_map.get_unit_at(cursor_position)
         if unit and unit.team == Team.PLAYER and unit.can_move and unit.can_act:
-            self.state.selected_unit_id = unit.unit_id
+            self.state.battle.selected_unit_id = unit.unit_id
             # Store original position for potential cancellation
-            self.state.original_unit_position = unit.position
-            self.state.battle_phase = BattlePhase.UNIT_MOVING
+            self.state.battle.original_unit_position = unit.position
+            self.state.battle.phase = BattlePhase.UNIT_MOVING
             movement_range = self.game_map.calculate_movement_range(unit)
-            self.state.set_movement_range(movement_range)
+            self.state.battle.set_movement_range(movement_range)
     
     def _handle_unit_movement_confirm(self, cursor_position: Vector2) -> None:
         """Handle confirmation during unit movement phase."""
-        if self.state.is_in_movement_range(cursor_position):
-            if self.state.selected_unit_id:
-                unit = self.game_map.get_unit(self.state.selected_unit_id)
+        if self.state.battle.is_in_movement_range(cursor_position):
+            if self.state.battle.selected_unit_id:
+                unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
                 if unit:
                     if self.game_map.move_unit(unit.unit_id, cursor_position):
                         # TODO: Emit unit moved event - will be handled by main Game class
@@ -175,13 +175,13 @@ class InputHandler:
                     unit.has_moved = True
                     
                     # Clear movement range and transition to action menu
-                    self.state.movement_range = VectorArray()
-                    self.state.battle_phase = BattlePhase.ACTION_MENU
+                    self.state.battle.movement_range = VectorArray()
+                    self.state.battle.phase = BattlePhase.ACTION_MENU
                     self._build_action_menu_for_unit(unit)
     
     def _handle_action_menu_confirm(self) -> None:
         """Handle confirmation in action menu phase."""
-        selected_action = self.state.get_selected_action()
+        selected_action = self.state.ui.get_selected_action()
         if selected_action:
             self._handle_action_selection(selected_action)
     
@@ -194,41 +194,41 @@ class InputHandler:
     
     def handle_cancel(self) -> None:
         """Handle cancel input based on current battle phase."""
-        if self.state.battle_phase == BattlePhase.UNIT_MOVING:
+        if self.state.battle.phase == BattlePhase.UNIT_MOVING:
             self._handle_movement_cancel()
-        elif self.state.battle_phase == BattlePhase.ACTION_MENU:
+        elif self.state.battle.phase == BattlePhase.ACTION_MENU:
             self._handle_action_menu_cancel()
-        elif self.state.battle_phase == BattlePhase.TARGETING:
+        elif self.state.battle.phase == BattlePhase.TARGETING:
             self._handle_targeting_cancel()
-        elif self.state.battle_phase == BattlePhase.UNIT_ACTING:
+        elif self.state.battle.phase == BattlePhase.UNIT_ACTING:
             self._handle_unit_acting_cancel()
     
     def _handle_movement_cancel(self) -> None:
         """Handle cancel during movement phase."""
         self.state.reset_selection()
-        self.state.battle_phase = BattlePhase.UNIT_SELECTION
+        self.state.battle.phase = BattlePhase.UNIT_SELECTION
     
     def _handle_action_menu_cancel(self) -> None:
         """Handle cancel during action menu phase."""
-        if self.state.selected_unit_id:
-            unit = self.game_map.get_unit(self.state.selected_unit_id)
+        if self.state.battle.selected_unit_id:
+            unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
             if unit and not unit.has_moved:
-                self.state.close_action_menu()
-                self.state.battle_phase = BattlePhase.UNIT_MOVING
+                self.state.ui.close_action_menu()
+                self.state.battle.phase = BattlePhase.UNIT_MOVING
                 movement_range = self.game_map.calculate_movement_range(unit)
-                self.state.set_movement_range(movement_range)
+                self.state.battle.set_movement_range(movement_range)
             else:
                 # Unit has already moved - restore to original position
                 self._restore_unit_to_original_position(unit)
     
     def _handle_targeting_cancel(self) -> None:
         """Handle cancel during targeting phase."""
-        self.state.attack_range = VectorArray()
-        self.state.selected_target = None
-        self.state.aoe_tiles = VectorArray()
-        self.state.battle_phase = BattlePhase.ACTION_MENU
-        if self.state.selected_unit_id:
-            unit = self.game_map.get_unit(self.state.selected_unit_id)
+        self.state.battle.attack_range = VectorArray()
+        self.state.battle.selected_target = None
+        self.state.battle.aoe_tiles = VectorArray()
+        self.state.battle.phase = BattlePhase.ACTION_MENU
+        if self.state.battle.selected_unit_id:
+            unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
             if unit:
                 self._build_action_menu_for_unit(unit)
     
@@ -236,39 +236,39 @@ class InputHandler:
         """Handle cancel during unit acting phase."""
         if self.combat_manager:
             self.combat_manager.clear_attack_state()
-        self.state.battle_phase = BattlePhase.ACTION_MENU
-        if self.state.selected_unit_id:
-            unit = self.game_map.get_unit(self.state.selected_unit_id)
+        self.state.battle.phase = BattlePhase.ACTION_MENU
+        if self.state.battle.selected_unit_id:
+            unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
             if unit:
                 self._build_action_menu_for_unit(unit)
     
     def _restore_unit_to_original_position(self, unit: Optional["Unit"]) -> None:
         """Restore unit to its original position if possible."""
-        if unit and self.state.original_unit_position is not None:
+        if unit and self.state.battle.original_unit_position is not None:
             # Restore unit to original position
-            if self.game_map.move_unit(unit.unit_id, self.state.original_unit_position):
+            if self.game_map.move_unit(unit.unit_id, self.state.battle.original_unit_position):
                 # TODO: Emit unit moved event for restoration
                 pass
             unit.has_moved = False
-            
+
             # Go back to movement phase to allow re-positioning
-            self.state.close_action_menu()
-            self.state.battle_phase = BattlePhase.UNIT_MOVING
+            self.state.ui.close_action_menu()
+            self.state.battle.phase = BattlePhase.UNIT_MOVING
             movement_range = self.game_map.calculate_movement_range(unit)
-            self.state.set_movement_range(movement_range)
-            
+            self.state.battle.set_movement_range(movement_range)
+
             # Position cursor on the restored unit
-            self.state.cursor_position = unit.position
+            self.state.cursor.set_position(unit.position)
         else:
             # Fallback: deselect and refresh
             self.state.reset_selection()
-            self.state.battle_phase = BattlePhase.UNIT_SELECTION
+            self.state.battle.phase = BattlePhase.UNIT_SELECTION
     
     def handle_tab_cycling(self) -> None:
         """Handle TAB key cycling for different phases."""
-        if self.state.battle_phase == BattlePhase.UNIT_SELECTION:
+        if self.state.battle.phase == BattlePhase.UNIT_SELECTION:
             self._cycle_selectable_units()
-        elif self.state.battle_phase == BattlePhase.UNIT_ACTING and self.combat_manager:
+        elif self.state.battle.phase == BattlePhase.UNIT_ACTING and self.combat_manager:
             self.combat_manager.cycle_targetable_enemies()
     
     def _cycle_selectable_units(self) -> None:
@@ -282,7 +282,7 @@ class InputHandler:
         if next_unit_id:
             unit = self.game_map.get_unit(next_unit_id)
             if unit:
-                self.state.cursor_position = unit.position
+                self.state.cursor.set_position(unit.position)
     
     def _refresh_selectable_units(self) -> None:
         """Update the list of selectable player units."""
@@ -295,22 +295,22 @@ class InputHandler:
     def handle_action_menu_input(self, event: InputEvent) -> None:
         """Handle input while action menu is open."""
         if event.key == Key.UP or event.key == Key.W:
-            self.state.move_action_menu_selection(-1)
+            self.state.ui.move_action_menu_selection(-1)
         elif event.key == Key.DOWN or event.key == Key.S:
-            self.state.move_action_menu_selection(1)
+            self.state.ui.move_action_menu_selection(1)
         elif event.is_confirm_key():
             self.handle_confirm()
         elif event.is_cancel_key():
             self.handle_cancel()
         # Add keyboard shortcuts
-        elif event.key == Key.A and "Attack" in self.state.action_menu_items:
-            self.state.action_menu_selection = self.state.action_menu_items.index("Attack")
+        elif event.key == Key.A and "Attack" in self.state.ui.action_menu_items:
+            self.state.ui.action_menu_selection = self.state.ui.action_menu_items.index("Attack")
             self.handle_confirm()
-        elif event.key == Key.W and "Wait" in self.state.action_menu_items:
-            self.state.action_menu_selection = self.state.action_menu_items.index("Wait")
+        elif event.key == Key.W and "Wait" in self.state.ui.action_menu_items:
+            self.state.ui.action_menu_selection = self.state.ui.action_menu_items.index("Wait")
             self.handle_confirm()
-        elif event.key == Key.M and "Move" in self.state.action_menu_items:
-            self.state.action_menu_selection = self.state.action_menu_items.index("Move")
+        elif event.key == Key.M and "Move" in self.state.ui.action_menu_items:
+            self.state.ui.action_menu_selection = self.state.ui.action_menu_items.index("Move")
             self.handle_confirm()
     
     def handle_main_menu_input(self, event: InputEvent) -> None:
@@ -336,27 +336,27 @@ class InputHandler:
     def handle_dialog_input(self, event: InputEvent) -> None:
         """Handle input while confirmation dialog is open."""
         if event.key in {Key.LEFT, Key.RIGHT}:
-            self.state.move_dialog_selection(1 if event.key == Key.RIGHT else -1)
+            self.state.ui.move_dialog_selection(1 if event.key == Key.RIGHT else -1)
         elif event.is_confirm_key():
             self._handle_dialog_confirmation()
         elif event.is_cancel_key():
-            self.state.close_dialog()
+            self.state.ui.close_dialog()
     
     def _handle_dialog_confirmation(self) -> None:
         """Handle dialog confirmation based on dialog type."""
-        if self.state.active_dialog == "confirm_end_turn":
-            if self.state.get_dialog_selection() == 0:  # Yes
+        if self.state.ui.active_dialog == "confirm_end_turn":
+            if self.state.ui.get_dialog_selection() == 0:  # Yes
                 if self.on_end_unit_turn:
                     self.on_end_unit_turn()
-        elif self.state.active_dialog == "confirm_friendly_fire":
+        elif self.state.ui.active_dialog == "confirm_friendly_fire":
             if (
-                self.state.get_dialog_selection() == 0  # Yes - proceed with attack
+                self.state.ui.get_dialog_selection() == 0  # Yes - proceed with attack
                 and self.combat_manager
             ):
                 success = self.combat_manager.execute_confirmed_attack()
                 if success and self.on_end_unit_turn:
                     self.on_end_unit_turn()
-        self.state.close_dialog()
+        self.state.ui.close_dialog()
     
     def handle_forecast_input(self, event: InputEvent) -> None:
         """Handle input while battle forecast is active."""
@@ -381,39 +381,39 @@ class InputHandler:
     
     def handle_end_turn_key(self) -> None:
         """Handle E key press to end turn (with confirmation)."""
-        self.state.open_dialog("confirm_end_turn")
+        self.state.ui.open_dialog("confirm_end_turn")
     
     def handle_attack_key(self) -> None:
         """Handle A key press for direct attack."""
         # Only allow during player turn and when a unit is selected
-        if self.state.current_team != 0 or not self.state.selected_unit_id:
+        if self.state.battle.current_team != 0 or not self.state.battle.selected_unit_id:
             return
-        
-        unit = self.game_map.get_unit(self.state.selected_unit_id)
+
+        unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
         if not unit or not unit.can_act or not self.combat_manager:
             return
         
         # Handle quick attack based on current phase
-        if self.state.battle_phase == BattlePhase.UNIT_SELECTION:
+        if self.state.battle.phase == BattlePhase.UNIT_SELECTION:
             # Unit just selected, transition to attack directly
-            self.state.battle_phase = BattlePhase.UNIT_ACTING
+            self.state.battle.phase = BattlePhase.UNIT_ACTING
             self.combat_manager.setup_attack_targeting(unit)
-        elif self.state.battle_phase == BattlePhase.UNIT_MOVING:
+        elif self.state.battle.phase == BattlePhase.UNIT_MOVING:
             # Unit is in movement, skip to attack
-            self.state.movement_range = VectorArray()
-            self.state.battle_phase = BattlePhase.UNIT_ACTING
+            self.state.battle.movement_range = VectorArray()
+            self.state.battle.phase = BattlePhase.UNIT_ACTING
             self.combat_manager.setup_attack_targeting(unit)
-        elif self.state.battle_phase == BattlePhase.ACTION_MENU:
+        elif self.state.battle.phase == BattlePhase.ACTION_MENU:
             # Use normal action selection
             self._handle_action_selection("Attack")
     
     def handle_wait_key(self) -> None:
         """Handle W key press for direct wait."""
         # Only allow during player turn and when a unit is selected
-        if self.state.current_team != 0 or not self.state.selected_unit_id:
+        if self.state.battle.current_team != 0 or not self.state.battle.selected_unit_id:
             return
-        
-        unit = self.game_map.get_unit(self.state.selected_unit_id)
+
+        unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
         if not unit:
             return
         
@@ -428,32 +428,32 @@ class InputHandler:
         """Handle the selected action from the action menu."""
         if action == "Move":
             # Go back to movement targeting
-            if self.state.selected_unit_id:
-                unit = self.game_map.get_unit(self.state.selected_unit_id)
+            if self.state.battle.selected_unit_id:
+                unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
                 if unit:
-                    self.state.close_action_menu()
-                    self.state.battle_phase = BattlePhase.UNIT_MOVING
+                    self.state.ui.close_action_menu()
+                    self.state.battle.phase = BattlePhase.UNIT_MOVING
                     movement_range = self.game_map.calculate_movement_range(unit)
-                    self.state.set_movement_range(movement_range)
+                    self.state.battle.set_movement_range(movement_range)
         
         elif action == "Attack":
             # Go to attack targeting
-            if self.state.selected_unit_id and self.combat_manager:
-                unit = self.game_map.get_unit(self.state.selected_unit_id)
+            if self.state.battle.selected_unit_id and self.combat_manager:
+                unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
                 if unit:
-                    self.state.close_action_menu()
-                    self.state.battle_phase = BattlePhase.UNIT_ACTING
+                    self.state.ui.close_action_menu()
+                    self.state.battle.phase = BattlePhase.UNIT_ACTING
                     self.combat_manager.setup_attack_targeting(unit)
         
         elif action == "Wait":
             # End unit's turn
-            if self.state.selected_unit_id:
-                unit = self.game_map.get_unit(self.state.selected_unit_id)
+            if self.state.battle.selected_unit_id:
+                unit = self.game_map.get_unit(self.state.battle.selected_unit_id)
                 if unit:
                     # When waiting, unit should not be able to move or act anymore
                     unit.has_moved = True  # Prevent further movement
                     unit.has_acted = True  # Prevent further actions
-                    self.state.close_action_menu()
+                    self.state.ui.close_action_menu()
                     if self.on_end_unit_turn:
                         self.on_end_unit_turn()
     
@@ -472,7 +472,7 @@ class InputHandler:
         # Wait action - always available
         actions.append("Wait")
         
-        self.state.open_action_menu(actions)
+        self.state.ui.open_action_menu(actions)
         
         # Auto-select the most appropriate action
         self._auto_select_action_menu_item(unit)
@@ -481,8 +481,8 @@ class InputHandler:
         """Automatically select the most appropriate action in the menu."""
         if not unit.can_act:
             # Unit can't act, select Wait
-            if "Wait" in self.state.action_menu_items:
-                self.state.action_menu_selection = self.state.action_menu_items.index("Wait")
+            if "Wait" in self.state.ui.action_menu_items:
+                self.state.ui.action_menu_selection = self.state.ui.action_menu_items.index("Wait")
             return
         
         # Check if there are ENEMY targets in attack range (not friendlies)
@@ -500,7 +500,7 @@ class InputHandler:
                 break
         
         # Select Attack only if there are enemy targets, otherwise Wait
-        if has_enemy_targets and "Attack" in self.state.action_menu_items:
-            self.state.action_menu_selection = self.state.action_menu_items.index("Attack")
-        elif "Wait" in self.state.action_menu_items:
-            self.state.action_menu_selection = self.state.action_menu_items.index("Wait")
+        if has_enemy_targets and "Attack" in self.state.ui.action_menu_items:
+            self.state.ui.action_menu_selection = self.state.ui.action_menu_items.index("Attack")
+        elif "Wait" in self.state.ui.action_menu_items:
+            self.state.ui.action_menu_selection = self.state.ui.action_menu_items.index("Wait")

--- a/src/game/turn_manager.py
+++ b/src/game/turn_manager.py
@@ -43,7 +43,7 @@ class TurnManager:
     def end_unit_turn(self) -> None:
         """End the current unit's turn and check if team turn should end."""
         self.state.reset_selection()
-        self.state.battle_phase = BattlePhase.UNIT_SELECTION
+        self.state.battle.phase = BattlePhase.UNIT_SELECTION
         
         # Refresh selectable units list
         if self.on_refresh_selectable_units:
@@ -66,7 +66,7 @@ class TurnManager:
     
     def start_enemy_turn(self) -> None:
         """Start the enemy team's turn."""
-        self.state.start_enemy_turn()
+        self.state.battle.start_enemy_turn()
         self.execute_simple_enemy_turn()
     
     def execute_simple_enemy_turn(self) -> None:
@@ -85,7 +85,7 @@ class TurnManager:
         # Emit turn started event for player
         self.emit_turn_started_event(Team.PLAYER)
         
-        self.state.battle_phase = BattlePhase.UNIT_SELECTION
+        self.state.battle.phase = BattlePhase.UNIT_SELECTION
         
         # Refresh selectable units for new turn
         if self.on_refresh_selectable_units:
@@ -102,29 +102,29 @@ class TurnManager:
     def end_player_turn(self) -> None:
         """End the current player turn and advance to next team."""
         # Store old team info for events
-        old_team = self.state.current_team
+        old_team = self.state.battle.current_team
         old_team_enum = Team(old_team)
         
         # Advance to next team
-        self.state.current_team = (self.state.current_team + 1) % 4
-        if self.state.current_team == 0:
-            self.state.current_turn += 1
+        self.state.battle.current_team = (self.state.battle.current_team + 1) % 4
+        if self.state.battle.current_team == 0:
+            self.state.battle.current_turn += 1
         
         # When changing teams, reset unit statuses for the new team
-        if self.state.current_team != old_team:
-            new_team_enum = Team(self.state.current_team)
+        if self.state.battle.current_team != old_team:
+            new_team_enum = Team(self.state.battle.current_team)
             
             # Emit turn ended for old team and turn started for new team
             self.emit_turn_ended_event(old_team_enum)
             self.emit_turn_started_event(new_team_enum)
             
-            self.reset_team_unit_statuses(self.state.current_team)
+            self.reset_team_unit_statuses(self.state.battle.current_team)
             
             # Show phase banner when changing teams
-            self.show_phase_banner(self.state.current_team)
+            self.show_phase_banner(self.state.battle.current_team)
             
             # Start enemy turn timer if switching to non-player team
-            if self.state.current_team != 0:
+            if self.state.battle.current_team != 0:
                 self.enemy_turn_start_time = time.time()
     
     def reset_team_unit_statuses(self, team: int) -> None:
@@ -151,14 +151,14 @@ class TurnManager:
     def update_enemy_turn_timing(self) -> None:
         """Handle automatic enemy turn progression."""
         # Only process if it's not the player's turn and we have a start time
-        if self.state.current_team != 0 and self.enemy_turn_start_time > 0:
+        if self.state.battle.current_team != 0 and self.enemy_turn_start_time > 0:
             elapsed_time = time.time() - self.enemy_turn_start_time
             
             # After enemy turn duration, automatically end the enemy turn
             if elapsed_time >= self.enemy_turn_duration:
                 # Show end turn message
                 team_names = {1: "Enemy", 2: "Ally", 3: "Neutral"}
-                team_name = team_names.get(self.state.current_team, "Unknown")
+                team_name = team_names.get(self.state.battle.current_team, "Unknown")
                 
                 if self.ui_manager:
                     self.ui_manager.show_banner(f"{team_name} Turn Complete")
@@ -171,22 +171,22 @@ class TurnManager:
     
     def emit_turn_started_event(self, team: Team) -> None:
         """Emit a turn started event."""
-        event = TurnStarted(turn=self.state.current_turn, team=team)
+        event = TurnStarted(turn=self.state.battle.current_turn, team=team)
         self.emit_event(event)
     
     def emit_turn_ended_event(self, team: Team) -> None:
         """Emit a turn ended event."""
-        event = TurnEnded(turn=self.state.current_turn, team=team)
+        event = TurnEnded(turn=self.state.battle.current_turn, team=team)
         self.emit_event(event)
     
     def is_player_turn(self) -> bool:
         """Check if it's currently the player's turn."""
-        return self.state.current_team == 0
+        return self.state.battle.current_team == 0
     
     def get_current_team(self) -> Team:
         """Get the current team as an enum."""
-        return Team(self.state.current_team)
+        return Team(self.state.battle.current_team)
     
     def get_current_turn(self) -> int:
         """Get the current turn number."""
-        return self.state.current_turn
+        return self.state.battle.current_turn

--- a/src/game/ui_manager.py
+++ b/src/game/ui_manager.py
@@ -57,19 +57,19 @@ class UIManager:
     # Overlay management
     def show_objectives(self) -> None:
         """Show the objectives overlay."""
-        self.state.open_overlay("objectives")
+        self.state.ui.open_overlay("objectives")
     
     def show_help(self) -> None:
         """Show the help overlay."""
-        self.state.open_overlay("help")
+        self.state.ui.open_overlay("help")
     
     def show_minimap(self) -> None:
         """Show the minimap overlay."""
-        self.state.open_overlay("minimap")
+        self.state.ui.open_overlay("minimap")
     
     def close_overlay(self) -> None:
         """Close the currently active overlay."""
-        self.state.close_overlay()
+        self.state.ui.close_overlay()
     
     # Banner management
     def show_banner(self, text: str, duration_ms: int = 2000) -> None:
@@ -122,7 +122,7 @@ class UIManager:
         if self.scenario.settings.turn_limit:
             content.append("")
             content.append(f"Turn Limit: {self.scenario.settings.turn_limit}")
-            content.append(f"Current Turn: {self.state.current_turn}")
+            content.append(f"Current Turn: {self.state.battle.current_turn}")
         
         content.append("")
         content.append("Press any key to continue...")
@@ -238,13 +238,13 @@ class UIManager:
                 
                 # Check if this position is in the camera view
                 screen_width, screen_height = self.renderer.get_screen_size()
-                camera_left = self.state.camera_position.x
+                camera_left = self.state.cursor.camera_position.x
                 camera_right = (
-                    self.state.camera_position.x + screen_width - 28
+                    self.state.cursor.camera_position.x + screen_width - 28
                 )  # Account for sidebar
-                camera_top = self.state.camera_position.y
+                camera_top = self.state.cursor.camera_position.y
                 camera_bottom = (
-                    self.state.camera_position.y + screen_height - 3
+                    self.state.cursor.camera_position.y + screen_height - 3
                 )  # Account for status
                 
                 if (
@@ -340,7 +340,7 @@ class UIManager:
                 title="Confirm",
                 message="End Player Turn?",
                 options=["Yes", "No"],
-                selected_option=self.state.get_dialog_selection(),
+                selected_option=self.state.ui.get_dialog_selection(),
             )
         elif dialog_type == "confirm_friendly_fire":
             friendly_fire_message = self.state.state_data.get(
@@ -356,7 +356,7 @@ class UIManager:
                 title="Friendly Fire Warning",
                 message=friendly_fire_message,
                 options=["Attack Anyway", "Cancel"],
-                selected_option=self.state.get_dialog_selection(),
+                selected_option=self.state.ui.get_dialog_selection(),
             )
         
         # Default dialog
@@ -368,7 +368,7 @@ class UIManager:
             title="Confirm",
             message="Are you sure?",
             options=["Yes", "No"],
-            selected_option=self.state.get_dialog_selection(),
+            selected_option=self.state.ui.get_dialog_selection(),
         )
     
     def build_battle_forecast(self) -> BattleForecastRenderData:

--- a/tests/test_aoe_visual.py
+++ b/tests/test_aoe_visual.py
@@ -68,24 +68,24 @@ def main():
     # Create game state in attack mode
     state = GameState()
     state.phase = GamePhase.BATTLE
-    state.battle_phase = BattlePhase.TARGETING
-    state.selected_unit_id = mage.unit_id
-    state.cursor_x, state.cursor_y = 3, 2  # Position that will hit both enemy1 and enemy3 in cross AOE
+    state.battle.phase = BattlePhase.TARGETING
+    state.battle.selected_unit_id = mage.unit_id
+    state.cursor.set_position(Vector2(2, 3))  # y,x
     
     # Calculate attack range
     attack_range = game_map.calculate_attack_range(mage)
-    state.set_attack_range(list(attack_range))
+    state.battle.set_attack_range(list(attack_range))
     
     # Set selected target and AOE tiles
-    state.selected_target = (state.cursor_x, state.cursor_y)
-    state.aoe_tiles = game_map.calculate_aoe_tiles(state.selected_target, mage.combat.aoe_pattern)
+    state.battle.selected_target = state.cursor.position
+    state.battle.aoe_tiles = game_map.calculate_aoe_tiles(state.battle.selected_target, mage.combat.aoe_pattern)
     
     print(f"Mage at ({mage.x}, {mage.y})")
     print(f"Attack range: {sorted(attack_range)}")
-    print(f"Cursor at ({state.cursor_x}, {state.cursor_y})")
-    print(f"Selected target: {state.selected_target}")
+    print(f"Cursor at ({state.cursor.position.x}, {state.cursor.position.y})")
+    print(f"Selected target: {state.battle.selected_target}")
     print(f"AOE pattern: {mage.combat.aoe_pattern}")
-    print(f"AOE tiles: {sorted(state.aoe_tiles)}")
+    print(f"AOE tiles: {sorted(state.battle.aoe_tiles)}")
     print()
     
     # Create simple renderer for display

--- a/tests/test_attack_targeting_debug.py
+++ b/tests/test_attack_targeting_debug.py
@@ -13,6 +13,7 @@ from src.game.map import GameMap  # noqa: E402
 from src.core.game_enums import UnitClass, Team  # noqa: E402
 from src.game.unit import Unit  # noqa: E402
 from src.core.game_state import GameState  # noqa: E402
+from src.core.data_structures import Vector2  # noqa: E402
 
 def main():
     print("Testing Attack Targeting with AOE")
@@ -67,35 +68,35 @@ def main():
     
     # Create game state and test the targeting
     state = GameState()
-    state.selected_unit_id = mage.unit_id
-    state.set_attack_range(list(attack_range))
+    state.battle.selected_unit_id = mage.unit_id
+    state.battle.set_attack_range(list(attack_range))
     
     # Simulate cursor movement
     print("\n" + "=" * 40)
     print("Simulating cursor movement:")
     
     # Move cursor to enemy position
-    state.cursor_x, state.cursor_y = 3, 2
+    state.cursor.set_position(Vector2(2, 3))
     print("\nCursor at (3, 2) - enemy position")
     
     # Check if we should show AOE
-    if (state.cursor_x, state.cursor_y) in state.attack_range:
-        state.selected_target = (state.cursor_x, state.cursor_y)
-        state.aoe_tiles = game_map.calculate_aoe_tiles((state.cursor_x, state.cursor_y), aoe_pattern)
-        print(f"  Selected target: {state.selected_target}")
-        print(f"  AOE tiles: {state.aoe_tiles}")
+    if state.cursor.position in state.battle.attack_range:
+        state.battle.selected_target = state.cursor.position
+        state.battle.aoe_tiles = game_map.calculate_aoe_tiles(state.cursor.position, aoe_pattern)
+        print(f"  Selected target: {state.battle.selected_target}")
+        print(f"  AOE tiles: {state.battle.aoe_tiles}")
     else:
         print("  Cursor not in attack range!")
     
     # Move cursor to empty position in range
-    state.cursor_x, state.cursor_y = 4, 2
+    state.cursor.set_position(Vector2(2, 4))
     print("\nCursor at (4, 2) - empty position in range")
     
-    if (state.cursor_x, state.cursor_y) in state.attack_range:
-        state.selected_target = (state.cursor_x, state.cursor_y)
-        state.aoe_tiles = game_map.calculate_aoe_tiles((state.cursor_x, state.cursor_y), aoe_pattern)
-        print(f"  Selected target: {state.selected_target}")
-        print(f"  AOE tiles: {state.aoe_tiles}")
+    if state.cursor.position in state.battle.attack_range:
+        state.battle.selected_target = state.cursor.position
+        state.battle.aoe_tiles = game_map.calculate_aoe_tiles(state.cursor.position, aoe_pattern)
+        print(f"  Selected target: {state.battle.selected_target}")
+        print(f"  AOE tiles: {state.battle.aoe_tiles}")
     else:
         print("  Cursor not in attack range!")
 


### PR DESCRIPTION
## Summary
- Split game state into dedicated `CursorState`, `UIState` and `BattleState` dataclasses
- Compose these substates in `GameState` with compatibility helpers
- Update input handling and rendering to reference new substate attributes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68ba23ed8c04832dae6b2ea70c5bc42d